### PR TITLE
Add PnP.PowerShell module version 1.12.0 to RequiredModules.psd1

### DIFF
--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -107,5 +107,6 @@
     'MicrosoftTeams'                                       = '6.7.0'
     'MSCloudLoginAssistant'                                = '1.1.28'
     'ReverseDSC'                                           = '2.0.0.22'
+    'PnP.PowerShell'                                       = '1.12.0'
 
 }


### PR DESCRIPTION
This pull request includes a small change to the `RequiredModules.psd1` file. The change adds a new module, `PnP.PowerShell`, with version `1.12.0` to the list of required modules.

* [`RequiredModules.psd1`](diffhunk://#diff-ee10b2e39d5d3ab414c10a7e24fff3d075d1f6ba0b9255eefb8f55ab6718920cR110): Added `PnP.PowerShell` module version `1.12.0` to the required modules list.