### PR TITLE
Update cEXOTransportConfig settings across environments and added merge

### DIFF
--- a/source/1-AllTenantsConfig/Exchange/cEXOTransportConfig.yml
+++ b/source/1-AllTenantsConfig/Exchange/cEXOTransportConfig.yml
@@ -1,5 +1,5 @@
 IsSingleInstance: Yes
 AddressBookPolicyRoutingEnabled: False
-MaxRecipientEnvelopeLimit: 590
+MaxRecipientEnvelopeLimit: 1000
 TenantId: '[x={ $azBuildParameters."$($Node.Environment)".AzTenantName }=]'
 ManagedIdentity: true

--- a/source/2-EnvironmentConfig/Dev/Exchange/cEXOTransportConfig.yml
+++ b/source/2-EnvironmentConfig/Dev/Exchange/cEXOTransportConfig.yml
@@ -1,0 +1,2 @@
+MaxRecipientEnvelopeLimit: 500
+ExternalPostmasterAddress: noreply@devenvironment.com

--- a/source/2-EnvironmentConfig/Prod/Exchange/cEXOTransportConfig.yml
+++ b/source/2-EnvironmentConfig/Prod/Exchange/cEXOTransportConfig.yml
@@ -1,5 +1,2 @@
-IsSingleInstance: Yes
-AddressBookPolicyRoutingEnabled: False
-MaxRecipientEnvelopeLimit: 1000
-TenantId: '[x={ $azBuildParameters."$($Node.Environment)".AzTenantName }=]'
-ManagedIdentity: true
+MaxRecipientEnvelopeLimit: 700
+ExternalPostmasterAddress: noreply@prodenvironment.com

--- a/source/2-EnvironmentConfig/Test/Exchange/cEXOTransportConfig.yml
+++ b/source/2-EnvironmentConfig/Test/Exchange/cEXOTransportConfig.yml
@@ -1,0 +1,2 @@
+MaxRecipientEnvelopeLimit: 600
+ExternalPostmasterAddress: noreply@testenvironment.com

--- a/source/Datum.yml
+++ b/source/Datum.yml
@@ -72,6 +72,9 @@ lookup_options:
       tuple_keys:
         - MailNickname
 
+  cEXOTransportConfig:
+    merge_hash: deep
+
   DscTagging:
     merge_hash: deep
   DscTagging\Layers:


### PR DESCRIPTION
This pull request includes several configuration updates across different environment files and introduces a new lookup option in the `Datum.yml` file. The most important changes include updates to the `MaxRecipientEnvelopeLimit` and the addition of `ExternalPostmasterAddress` in various environment configurations, as well as a new `merge_hash` option for `cEXOTransportConfig`.

Updates to environment configurations:

* [`source/1-AllTenantsConfig/Exchange/cEXOTransportConfig.yml`](diffhunk://#diff-a751b0dee3041728cbe53fed7187c2384ae6b819fedccb2785fdcebef7d79cabL3-R3): Increased `MaxRecipientEnvelopeLimit` from 590 to 1000.
* [`source/2-EnvironmentConfig/Dev/Exchange/cEXOTransportConfig.yml`](diffhunk://#diff-8682b656c98d48b8c092ca5a972729469ad896456cd7d393eef699bd0ca4c255R1-R2): Added `MaxRecipientEnvelopeLimit` set to 500 and `ExternalPostmasterAddress` set to `noreply@devenvironment.com`.
* [`source/2-EnvironmentConfig/Prod/Exchange/cEXOTransportConfig.yml`](diffhunk://#diff-dffc84a6a3dfad95f5a185d428f11207ad28ca360a54fd3fe242a9b9bb1455e0L1-R2): Removed several configurations and updated `MaxRecipientEnvelopeLimit` to 700 and `ExternalPostmasterAddress` to `noreply@prodenvironment.com`.
* [`source/2-EnvironmentConfig/Test/Exchange/cEXOTransportConfig.yml`](diffhunk://#diff-ba344a8a13dff3fa45e239475806a35fd90d006c69a72ba7c92fc40656299b2bR1-R2): Added `MaxRecipientEnvelopeLimit` set to 600 and `ExternalPostmasterAddress` set to `noreply@testenvironment.com`.

New lookup option:

* [`source/Datum.yml`](diffhunk://#diff-2557ad4d34b586d803f88246acd56d395980e8a831b0f6f074b8c254ac4b97e1R75-R77): Added `merge_hash: deep` for `cEXOTransportConfig` in the `lookup_options` section.