### PR TITLE
Update Microsoft365DSC version to 1.24.1204.1 in RequiredModules.psd1

### DIFF
--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -57,7 +57,7 @@
     'Microsoft.Graph.Identity.DirectoryManagement'         = '2.24.0'
 
     # Microsoft365DSC
-    Microsoft365DSC                                        = '1.24.1127.1'
+    Microsoft365DSC                                        = '1.24.1204.1'
 
     <#
         To update Microsoft365DSC and its dependencies, do the following steps:


### PR DESCRIPTION
This pull request includes a minor update to the `RequiredModules.psd1` file. The change updates the version of the `Microsoft365DSC` module to ensure compatibility with the latest features and fixes.

* [`RequiredModules.psd1`](diffhunk://#diff-ee10b2e39d5d3ab414c10a7e24fff3d075d1f6ba0b9255eefb8f55ab6718920cL60-R60): Updated `Microsoft365DSC` module version from `1.24.1127.1` to `1.24.1204.1`.