### PR TITLE
Added certificate-based authentication for creating apps

### DIFF
--- a/lab/10 Setup App Registrations.ps1
+++ b/lab/10 Setup App Registrations.ps1
@@ -23,8 +23,19 @@ foreach ($environmentName in $environments)
     Write-Host "Working in environment '$environmentName'" -ForegroundColor Magenta
     Write-Host "Connecting to Azure subscription '$($environment.AzSubscriptionId)' in tenant '$($environment.AzTenantId)'"
 
-    Connect-M365Dsc -TenantId $environment.AzTenantId -TenantName $environment.AzTenantName -SubscriptionId $environment.AzSubscriptionId
-    if (-not (Test-M365DscConnection -TenantId $environment.AzTenantId -SubscriptionId $environment.AzSubscriptionId))
+    $param = @{
+        TenantId   = $environment.AzTenantId
+        TenantName = $environment.AzTenantName
+    }
+    if (-not [string]::IsNullOrEmpty($environment.AzSubscriptionId))
+    {
+        $param.SubscriptionId = $environment.AzSubscriptionId
+    }
+
+    Connect-M365Dsc @param
+
+    $param.Remove('TenantName')
+    if (-not (Test-M365DscConnection @param))
     {
         Write-Error "Failed to connect to Azure subscription '$($environment.AzSubscriptionId)' in tenant '$($environment.AzTenantId)'" -ErrorAction Stop
     }

--- a/lab/11 Test Connection.ps1
+++ b/lab/11 Test Connection.ps1
@@ -3,7 +3,10 @@ param (
     [string[]]$EnvironmentName,
 
     [Parameter()]
-    [switch]$DoNotDisconnect
+    [switch]$DoNotDisconnect,
+
+    [Parameter()]
+    [string]$SetupApplicationName = 'M365DscSetupApplication'
 )
 
 $requiredModulesPath = (Resolve-Path -Path $PSScriptRoot\..\output\RequiredModules).Path
@@ -26,12 +29,12 @@ Write-Host "Setting up environments: $($environments -join ', ')" -ForegroundCol
 foreach ($envName in $environments)
 {
     $environment = $datum.Global.Azure.Environments."$envName"
-    $setupIdentity = $environment.Identities | Where-Object Name -EQ M365DscSetupApplication
+    $setupIdentity = $environment.Identities | Where-Object Name -EQ $SetupApplicationName
     Write-Host "Testing connection to environment '$envName'" -ForegroundColor Magenta
 
     if (-not $setupIdentity.ApplicationId)
     {
-        Write-Error "The setup identity 'M365DscSetupApplication' for environment '$envName' is not defined. Please run the 'Setup App Registrations' script first." -ErrorAction Stop
+        Write-Error "The setup identity '$SetupApplicationName' for environment '$envName' is not defined. Please run the '10 Setup App Registrations.ps1' script first." -ErrorAction Stop
     }
 
     $param = @{

--- a/lab/11 Test Connection.ps1
+++ b/lab/11 Test Connection.ps1
@@ -29,11 +29,16 @@ foreach ($envName in $environments)
     $setupIdentity = $environment.Identities | Where-Object Name -EQ M365DscSetupApplication
     Write-Host "Testing connection to environment '$envName'" -ForegroundColor Magenta
 
+    if (-not $setupIdentity.ApplicationId)
+    {
+        Write-Error "The setup identity 'M365DscSetupApplication' for environment '$envName' is not defined. Please run the 'Setup App Registrations' script first." -ErrorAction Stop
+    }
+
     $param = @{
-        TenantId           = $environment.AzTenantId
-        TenantName         = $environment.AzTenantName
-        SubscriptionId     = $environment.AzSubscriptionId
-        ServicePrincipalId = $setupIdentity.ApplicationId
+        TenantId               = $environment.AzTenantId
+        TenantName             = $environment.AzTenantName
+        SubscriptionId         = $environment.AzSubscriptionId
+        ServicePrincipalId     = $setupIdentity.ApplicationId
     }
     if ($setupIdentity.ApplicationSecret)
     {

--- a/lab/11 Test Connection.ps1
+++ b/lab/11 Test Connection.ps1
@@ -30,11 +30,18 @@ foreach ($envName in $environments)
     Write-Host "Testing connection to environment '$envName'" -ForegroundColor Magenta
 
     $param = @{
-        TenantId               = $environment.AzTenantId
-        TenantName             = $environment.AzTenantName
-        SubscriptionId         = $environment.AzSubscriptionId
-        ServicePrincipalId     = $setupIdentity.ApplicationId
-        ServicePrincipalSecret = $setupIdentity.ApplicationSecret | ConvertTo-SecureString -AsPlainText -Force
+        TenantId           = $environment.AzTenantId
+        TenantName         = $environment.AzTenantName
+        SubscriptionId     = $environment.AzSubscriptionId
+        ServicePrincipalId = $setupIdentity.ApplicationId
+    }
+    if ($setupIdentity.ApplicationSecret)
+    {
+        $param.ServicePrincipalSecret = $setupIdentity.ApplicationSecret
+    }
+    else
+    {
+        $param.CertificateThumbprint = $setupIdentity.CertificateThumbprint
     }
 
     Connect-M365Dsc @param -ErrorAction Stop

--- a/lab/AzHelpers.psm1
+++ b/lab/AzHelpers.psm1
@@ -646,7 +646,7 @@ function Test-M365DscConnection
 
     if ([string]::IsNullOrEmpty($SubscriptionId))
     {
-        Write-Host "Azure context subscription ID is not set."
+        Write-Host 'Azure context subscription ID is not set.'
     }
     elseif ($azContext.Subscription.Id -ne $SubscriptionId)
     {
@@ -747,9 +747,9 @@ function Connect-M365DscAzure
         else
         {
             $param = @{
-                Tenant         = $TenantId
-                ErrorAction    = 'Stop'
-                WarningAction  = 'Ignore'
+                Tenant        = $TenantId
+                ErrorAction   = 'Stop'
+                WarningAction = 'Ignore'
             }
             if ($SubscriptionId)
             {
@@ -936,20 +936,29 @@ function Add-M365DscIdentityPermission
         [string]$AccessType = 'Update'
     )
 
-    Write-Host 'Adding Azure permissions' -ForegroundColor Magenta
-    if ($AccessType -eq 'Update')
+    $azureContext = Get-AzContext
+
+    if (-not $azureContext.SubscriptionId)
     {
-        if (-not (Get-AzRoleAssignment -ObjectId $Identity.AppPrincipalId -RoleDefinitionName Owner))
-        {
-            New-AzRoleAssignment -PrincipalId $Identity.AppPrincipalId -RoleDefinitionName Owner | Out-Null
-            Write-Host "Assigning the application '$($Identity.DisplayName)' to the role 'Owner'."
-        }
-        else
-        {
-            Write-Host "The application '$($Identity.DisplayName)' is already assigned to the role 'Owner'."
-        }
+        Write-Host 'No Azure subscription available. Skipping Azure permissions.' -ForegroundColor Yellow
     }
-    Write-Host 'Done adding Azure permissions' -ForegroundColor Magenta
+    else
+    {
+        Write-Host 'Adding Azure permissions' -ForegroundColor Magenta
+        if ($AccessType -eq 'Update')
+        {
+            if (-not (Get-AzRoleAssignment -ObjectId $Identity.AppPrincipalId -RoleDefinitionName Owner))
+            {
+                New-AzRoleAssignment -PrincipalId $Identity.AppPrincipalId -RoleDefinitionName Owner | Out-Null
+                Write-Host "Assigning the application '$($Identity.DisplayName)' to the role 'Owner'."
+            }
+            else
+            {
+                Write-Host "The application '$($Identity.DisplayName)' is already assigned to the role 'Owner'."
+            }
+        }
+        Write-Host 'Done adding Azure permissions' -ForegroundColor Magenta
+    }
 
     #------------------------------------------------------------------------------
 

--- a/lab/AzHelpers.psm1
+++ b/lab/AzHelpers.psm1
@@ -686,9 +686,9 @@ function Connect-M365DscAzure
         [Parameter(Mandatory = $true, ParameterSetName = 'Interactive')]
         [string]$TenantId,
 
-        [Parameter(Mandatory = $true, ParameterSetName = 'AppSecret')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'Certificate')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'Interactive')]
+        [Parameter(ParameterSetName = 'AppSecret')]
+        [Parameter(ParameterSetName = 'Certificate')]
+        [Parameter(ParameterSetName = 'Interactive')]
         [string]$SubscriptionId,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'AppSecret')]
@@ -720,15 +720,15 @@ function Connect-M365DscAzure
     {
         if ($PSCmdlet.ParameterSetName -eq 'AppSecret')
         {
-            $subscription = Connect-AzAccount -ServicePrincipal -Credential $cred -Tenant $TenantId -ErrorAction Stop -WarningAction Ignore *>&1 #| Write-Verbose
+            $subscription = Connect-AzAccount -ServicePrincipal -Credential $cred -Tenant $TenantId -ErrorAction Stop -WarningAction Ignore *>&1
         }
         elseif ($PSCmdlet.ParameterSetName -eq 'Certificate')
         {
-            $subscription = Connect-AzAccount -Tenant $TenantId -ApplicationId $ServicePrincipalId -CertificateThumbprint $CertificateThumbprint -SubscriptionId $SubscriptionId -ErrorAction Stop -WarningAction Ignore *>&1 #| Write-Verbose
+            $subscription = Connect-AzAccount -Tenant $TenantId -ApplicationId $ServicePrincipalId -CertificateThumbprint $CertificateThumbprint -ErrorAction Stop -WarningAction Ignore *>&1
         }
         else
         {
-            $subscription = Connect-AzAccount -Tenant $TenantId -SubscriptionId $SubscriptionId -ErrorAction Stop -WarningAction Ignore *>&1 #| Write-Verbose
+            $subscription = Connect-AzAccount -Tenant $TenantId -SubscriptionId $SubscriptionId -ErrorAction Stop -WarningAction Ignore *>&1
         }
         Write-Host "Successfully connected to Azure subscription '$($subscription.Context.Subscription.Name)' ($($subscription.Context.Subscription.Id))' with account '$($subscription.Context.Account.Id)'"
     }
@@ -850,9 +850,9 @@ function Connect-M365Dsc
         [Parameter(Mandatory = $true, ParameterSetName = 'Interactive')]
         [string]$TenantName,
 
-        [Parameter(Mandatory = $true, ParameterSetName = 'AppSecret')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'Certificate')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'Interactive')]
+        [Parameter(ParameterSetName = 'AppSecret')]
+        [Parameter(ParameterSetName = 'Certificate')]
+        [Parameter(ParameterSetName = 'Interactive')]
         [string]$SubscriptionId,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'AppSecret')]

--- a/lab/AzHelpers.psm1
+++ b/lab/AzHelpers.psm1
@@ -300,7 +300,7 @@ function Get-GraphPermission
 function Connect-Azure
 {
     [CmdletBinding()]
-    param(
+    param (
         [Parameter(Mandatory = $true)]
         [string]$TenantId,
 
@@ -352,7 +352,7 @@ function Connect-Azure
 function Connect-EXO
 {
     [CmdletBinding()]
-    param(
+    param (
         [Parameter(Mandatory = $true)]
         [string]$TenantId,
 
@@ -680,20 +680,26 @@ function Test-M365DscConnection
 function Connect-M365DscAzure
 {
     [CmdletBinding(DefaultParameterSetName = 'Interactive')]
-    param(
+    param (
         [Parameter(Mandatory = $true, ParameterSetName = 'AppSecret')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Certificate')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Interactive')]
         [string]$TenantId,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'AppSecret')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Certificate')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Interactive')]
         [string]$SubscriptionId,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'AppSecret')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Certificate')]
         [string]$ServicePrincipalId,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'AppSecret')]
         [securestring]$ServicePrincipalSecret,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Certificate')]
+        [string]$CertificateThumbprint,
 
         [Parameter()]
         [string[]]$Scopes = ('RoleManagement.ReadWrite.Directory',
@@ -715,6 +721,10 @@ function Connect-M365DscAzure
         if ($PSCmdlet.ParameterSetName -eq 'AppSecret')
         {
             $subscription = Connect-AzAccount -ServicePrincipal -Credential $cred -Tenant $TenantId -ErrorAction Stop -WarningAction Ignore *>&1 #| Write-Verbose
+        }
+        elseif ($PSCmdlet.ParameterSetName -eq 'Certificate')
+        {
+            $subscription = Connect-AzAccount -Tenant $TenantId -ApplicationId $ServicePrincipalId -CertificateThumbprint $CertificateThumbprint -SubscriptionId $SubscriptionId -ErrorAction Stop -WarningAction Ignore *>&1 #| Write-Verbose
         }
         else
         {
@@ -762,20 +772,26 @@ function Connect-M365DscAzure
 function Connect-M365DscExchangeOnline
 {
     [CmdletBinding(DefaultParameterSetName = 'Interactive')]
-    param(
+    param (
         [Parameter(Mandatory = $true, ParameterSetName = 'AppSecret')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Certificate')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Interactive')]
         [string]$TenantId,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'AppSecret')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Certificate')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Interactive')]
         [string]$TenantName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'AppSecret')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Certificate')]
         [string]$ServicePrincipalId,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'AppSecret')]
-        [securestring]$ServicePrincipalSecret
+        [securestring]$ServicePrincipalSecret,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Certificate')]
+        [string]$CertificateThumbprint
     )
 
     try
@@ -792,6 +808,10 @@ function Connect-M365DscExchangeOnline
             $tokenResponse = Invoke-RestMethod -Uri "https://login.microsoftonline.com/$TenantId/oauth2/v2.0/token" -Method POST -Body $tokenBody
 
             Connect-ExchangeOnline -AccessToken $tokenResponse.access_token -Organization $TenantName -ShowBanner:$false
+        }
+        elseif ($PSCmdlet.ParameterSetName -eq 'Certificate')
+        {
+            Connect-ExchangeOnline -CertificateThumbprint $CertificateThumbprint -AppId $ServicePrincipalId -Organization $TenantName -ShowBanner:$false
         }
         else
         {
@@ -821,22 +841,29 @@ function Connect-M365Dsc
     [CmdletBinding(DefaultParameterSetName = 'Interactive')]
     param (
         [Parameter(Mandatory = $true, ParameterSetName = 'AppSecret')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Certificate')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Interactive')]
         [string]$TenantId,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'AppSecret')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Certificate')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Interactive')]
         [string]$TenantName,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'AppSecret')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Certificate')]
         [Parameter(Mandatory = $true, ParameterSetName = 'Interactive')]
         [string]$SubscriptionId,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'AppSecret')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'Certificate')]
         [string]$ServicePrincipalId,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'AppSecret')]
-        [securestring]$ServicePrincipalSecret
+        [securestring]$ServicePrincipalSecret,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Certificate')]
+        [string]$CertificateThumbprint
     )
 
     Disconnect-M365Dsc -ErrorAction SilentlyContinue


### PR DESCRIPTION
This pull request includes several updates to improve the handling of Azure and Microsoft 365 connections, particularly adding support for certificate-based authentication and improving parameter handling. The most important changes are grouped by theme:

### Improvements to parameter handling:
* Updated `lab/10 Setup App Registrations.ps1` to use a parameter hash table for `Connect-M365Dsc` and conditionally include `SubscriptionId` if it is not null or empty. (`[lab/10 Setup App Registrations.ps1L26-R38](diffhunk://#diff-63d640404f92c93a92c5dabd3570e51d3653c3740e31881353e5223501d38b77L26-R38)`)
* Added `SetupApplicationName` parameter to `lab/11 Test Connection.ps1` and updated its usage to dynamically reference the setup application name. (`[[1]](diffhunk://#diff-26f3c23f3c8da0229c60705fa1de11ef56644abc5f739b3eb1649c1d2744c192L6-R9)`, `[[2]](diffhunk://#diff-26f3c23f3c8da0229c60705fa1de11ef56644abc5f739b3eb1649c1d2744c192L29-R52)`)
* Made `SubscriptionId` parameter optional in `Test-M365DscConnection` function in `lab/AzHelpers.psm1`. (`[[1]](diffhunk://#diff-5b60aebdbcf74da39212c98097ba5ee2a3d544540d274c43f4e43a06779de6c6L604-R604)`, `[[2]](diffhunk://#diff-5b60aebdbcf74da39212c98097ba5ee2a3d544540d274c43f4e43a06779de6c6L647-R651)`)

### Support for certificate-based authentication:
* Added support for certificate-based authentication in `Connect-M365DscAzure`, `Connect-M365DscExchangeOnline`, and `Connect-M365Dsc` functions in `lab/AzHelpers.psm1`. (`[[1]](diffhunk://#diff-5b60aebdbcf74da39212c98097ba5ee2a3d544540d274c43f4e43a06779de6c6R689-R707)`, `[[2]](diffhunk://#diff-5b60aebdbcf74da39212c98097ba5ee2a3d544540d274c43f4e43a06779de6c6L717-R767)`, `[[3]](diffhunk://#diff-5b60aebdbcf74da39212c98097ba5ee2a3d544540d274c43f4e43a06779de6c6R813-R830)`, `[[4]](diffhunk://#diff-5b60aebdbcf74da39212c98097ba5ee2a3d544540d274c43f4e43a06779de6c6R880-R902)`)

### Improvements to Azure connection handling:
* Enhanced `Add-M365DscIdentityPermission` function to handle scenarios where no Azure subscription is available, skipping Azure permissions if necessary. (`[lab/AzHelpers.psm1R939-R946](diffhunk://#diff-5b60aebdbcf74da39212c98097ba5ee2a3d544540d274c43f4e43a06779de6c6R939-R946)`)