### PR TITLE
Fixing merge behavior for ADConditionalAccessPolicies

### DIFF
--- a/source/1-AllTenantsConfig/AzureAd/cAADConditionalAccessPolicy.yml
+++ b/source/1-AllTenantsConfig/AzureAd/cAADConditionalAccessPolicy.yml
@@ -1,7 +1,7 @@
 Items:
-  - DisplayName: "SEC001-Block-Legacy-Authentication-All-App"
+  - DisplayName: SEC001-Block-Legacy-Authentication-All-App
     Id: d85efd15-44a8-4a08-ba18-4ef0b9d29bf7
-    State: "EnabledForReportingButNotEnforced"
+    State: EnabledForReportingButNotEnforced
     IncludeApplications:
       - All
     IncludeUsers:

--- a/source/2-EnvironmentConfig/Prod/AzureAd/cAADConditionalAccessPolicy.yml
+++ b/source/2-EnvironmentConfig/Prod/AzureAd/cAADConditionalAccessPolicy.yml
@@ -1,0 +1,3 @@
+Items:
+  - DisplayName: SEC001-Block-Legacy-Authentication-All-App
+    State: Enabled

--- a/source/Datum.yml
+++ b/source/Datum.yml
@@ -56,10 +56,10 @@ lookup_options:
   Configurations:
     merge_basetype_array: Unique
 
-  ADConditionalAccessPolicies:
+  cAADConditionalAccessPolicy:
     merge_hash: deep
-  ADConditionalAccessPolicies\Items:
-    merge_hash_array: UniqueKeyValTuples
+  cAADConditionalAccessPolicy\Items:
+    merge_hash_array: DeepTuple
     merge_options:
       tuple_keys:
         - DisplayName


### PR DESCRIPTION
This pull request includes changes to the configuration of Azure AD Conditional Access Policies and updates to the lookup options in the `Datum.yml` file. The most important changes are as follows:

Azure AD Conditional Access Policies:

* [`source/1-AllTenantsConfig/AzureAd/cAADConditionalAccessPolicy.yml`](diffhunk://#diff-048cc6d84f5b5d37eba4df1fd2b73e1619fe68648eb14566cd87a332ae22cde9L2-R4): Updated the `DisplayName` and `State` values to remove quotes.
* [`source/2-EnvironmentConfig/Prod/AzureAd/cAADConditionalAccessPolicy.yml`](diffhunk://#diff-e3b3f05fe88972085f1d7e7c9c4b389da5c7f50eae4cddb86b994bbe8a18e392R1-R3): Added a new item with `DisplayName` and `State` values.

Lookup options updates:

* [`source/Datum.yml`](diffhunk://#diff-2557ad4d34b586d803f88246acd56d395980e8a831b0f6f074b8c254ac4b97e1L59-R62): Renamed `ADConditionalAccessPolicies` to `cAADConditionalAccessPolicy` and updated the merge strategies for keys and arrays.