### PR TITLE
Update 2501

### DIFF
--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -57,7 +57,7 @@
     'Microsoft.Graph.Identity.DirectoryManagement'         = '2.25.0'
 
     # Microsoft365DSC
-    Microsoft365DSC                                        = '1.24.1218.1'
+    Microsoft365DSC                                        = '1.25.115.1'
 
     <#
         To update Microsoft365DSC and its dependencies, do the following steps:
@@ -103,9 +103,9 @@
     'Microsoft.Graph.Sites'                                = '2.25.0'
     'Microsoft.Graph.Users'                                = '2.25.0'
     'Microsoft.Graph.Users.Actions'                        = '2.25.0'
-    'Microsoft.PowerApps.Administration.PowerShell'        = '2.0.202'
+    'Microsoft.PowerApps.Administration.PowerShell'        = '2.0.203'
     'MicrosoftTeams'                                       = '6.7.0'
-    'MSCloudLoginAssistant'                                = '1.1.31'
+    'MSCloudLoginAssistant'                                = '1.1.34'
     'ReverseDSC'                                           = '2.0.0.22'
     'PnP.PowerShell'                                       = '1.12.0'
 

--- a/lab/20 Create Agent VMs.ps1
+++ b/lab/20 Create Agent VMs.ps1
@@ -142,6 +142,12 @@ foreach ($lab in $labs)
     $azIdentity = New-M365DscIdentity -Name "Lcm$($datum.Global.ProjectSettings.Name)$envName" -PassThru
     Write-Host "Setting permissions for managed identity 'Lcm$($datum.Global.ProjectSettings.Name)$envName' in environment '$envName'"
     Add-M365DscIdentityPermission -Identity $azIdentity -AccessType Update
+
+    $vm = Get-LabVM
+
+    Invoke-LabCommand -ComputerName $vm -ScriptBlock {
+        Set-Item -Path WSMan:\localhost\MaxEnvelopeSizekb -Value 8192
+    } -ActivityName 'Setting WSMan MaxEnvelopeSizekb to 8192 for VMs in environment'
 }
 
 Write-Host 'Finished assigning managed identity to VMs and setting permissions for Microsoft365DSC workloads' -ForegroundColor Green


### PR DESCRIPTION
This pull request includes updates to module versions and a script enhancement for setting WSMan properties on VMs. The changes are as follows:

Module version updates:

* [`RequiredModules.psd1`](diffhunk://#diff-ee10b2e39d5d3ab414c10a7e24fff3d075d1f6ba0b9255eefb8f55ab6718920cL60-R60): Updated `Microsoft365DSC` from version `1.24.1218.1` to `1.25.115.1`.
* [`RequiredModules.psd1`](diffhunk://#diff-ee10b2e39d5d3ab414c10a7e24fff3d075d1f6ba0b9255eefb8f55ab6718920cL106-R108): Updated `Microsoft.PowerApps.Administration.PowerShell` from version `2.0.202` to `2.0.203`.
* [`RequiredModules.psd1`](diffhunk://#diff-ee10b2e39d5d3ab414c10a7e24fff3d075d1f6ba0b9255eefb8f55ab6718920cL106-R108): Updated `MSCloudLoginAssistant` from version `1.1.31` to `1.1.34`.

Script enhancement:

* [`lab/20 Create Agent VMs.ps1`](diffhunk://#diff-8734d49d7181df5ea04b83072fb25a298faf3d7038453fb8b6764fed2b0b30d0R145-R150): Added commands to retrieve VMs and set the WSMan `MaxEnvelopeSizekb` property to `8192` for VMs in the environment.